### PR TITLE
Check server run status on MainActivity resume

### DIFF
--- a/app/src/main/java/com/skylake/skytv/jgorunner/activities/MainActivity.kt
+++ b/app/src/main/java/com/skylake/skytv/jgorunner/activities/MainActivity.kt
@@ -133,6 +133,13 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+
+        if (isServerRunning)
+            onJTVServerRun()
+    }
+
     @SuppressLint("UnspecifiedRegisterReceiverFlag")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)


### PR DESCRIPTION
## Issue

When the user comes back to the MainActivity after logging in through the WEB TV, the playlist URL background doesn't turn green and no IPTV is automatically launched.

## Fix

Implement the server check feature on resume of MainActivity