### PR TITLE
Customizable Autoplay Added for both default ui and custom playlist ui on the Zone ui home Screen

### DIFF
--- a/app/src/main/java/com/skylake/skytv/jgorunner/data/SkySharedPref.kt
+++ b/app/src/main/java/com/skylake/skytv/jgorunner/data/SkySharedPref.kt
@@ -151,9 +151,16 @@ class SkySharedPref(context: Context) {
         @SharedPrefKey("currChannelUrl") var currChannelUrl: String? = "",
         @SharedPrefKey("unitHolder") var unitHolder: Int = 0,
         @SharedPrefKey("customPlaylistSupport") var customPlaylistSupport: Boolean = false,
+        
         @SharedPrefKey("genericTvIcon") var genericTvIcon: Boolean = false,
+        // tv player active
+        @SharedPrefKey("tv_player_active") var tvPlayerActive: Boolean = false,
+        @SharedPrefKey("autoPlaySuppressUntil") var autoPlaySuppressUntil: Long = 0L,
 
-
+        // Zone TV specific settings(20s)
+        @SharedPrefKey("zoneAutoLoopEnabled") var zoneAutoLoopEnabled: Boolean = false,
+        @SharedPrefKey("zoneAutoLoopIntervalSec") var zoneAutoLoopIntervalSec: Int = 20,
+        @SharedPrefKey("isInZoneScreen") var isInZoneScreen: Boolean = false,
     )
 
 

--- a/app/src/main/java/com/skylake/skytv/jgorunner/services/player/ExoPlayJet.kt
+++ b/app/src/main/java/com/skylake/skytv/jgorunner/services/player/ExoPlayJet.kt
@@ -113,4 +113,12 @@ class ExoPlayJet : ComponentActivity() {
             Log.d(TAG, "Loaded channel from direct intent extras: $channelNameState")
         }
     }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        // Mark player as inactive for Zone TV autoplay
+        val prefManager = SkySharedPref.getInstance(this)
+        prefManager.myPrefs.tvPlayerActive = false
+        prefManager.savePreferences()
+    }
 }

--- a/app/src/main/java/com/skylake/skytv/jgorunner/ui/dev/Main_LayoutTV.kt
+++ b/app/src/main/java/com/skylake/skytv/jgorunner/ui/dev/Main_LayoutTV.kt
@@ -189,7 +189,7 @@ fun Main_LayoutTV(context: Context?) {
             fetched = true
         }
 
-        if (preferenceManager.myPrefs.startTvAutomatically) {
+        if (preferenceManager.myPrefs.startTvAutomatically || preferenceManager.myPrefs.zoneAutoLoopEnabled) {
             if (!AppStartTracker.shouldPlayChannel &&
                 filteredChannels.value.isNotEmpty()) {
 

--- a/app/src/main/java/com/skylake/skytv/jgorunner/ui/screens/ZoneScreen.kt
+++ b/app/src/main/java/com/skylake/skytv/jgorunner/ui/screens/ZoneScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.Switch
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -52,6 +53,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusRestorer
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shadow
@@ -74,7 +76,13 @@ import com.skylake.skytv.jgorunner.ui.dev.Main_Layout
 import com.skylake.skytv.jgorunner.ui.dev.Main_LayoutTV
 import com.skylake.skytv.jgorunner.ui.dev.Main_LayoutTV_3rd
 import com.skylake.skytv.jgorunner.ui.dev.Main_Layout_3rd
+import com.skylake.skytv.jgorunner.ui.dev.ChannelUtils
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.skylake.skytv.jgorunner.ui.dev.M3UChannelExp
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.isActive
 import kotlin.random.Random
 
 @SuppressLint("NewApi")
@@ -103,7 +111,27 @@ fun ZoneScreen(context: Context, onNavigate: (String) -> Unit) {
 
     var selectedTabIndex by remember { mutableIntStateOf(savedTabIndex) }
     val tabFocusRequester = remember { FocusRequester() }
+    var zoneAutoLoopEnabled by remember { mutableStateOf(preferenceManager.myPrefs.zoneAutoLoopEnabled) }
 
+    // Mark that we're inside Zone screen for lifecycle scoping    
+    LaunchedEffect(Unit) {
+        preferenceManager.myPrefs.isInZoneScreen = true
+        if (isRemoteNavigation) {
+            preferenceManager.myPrefs.startTvAutomatically = true
+            preferenceManager.myPrefs.tvPlayerActive = false
+        }
+        preferenceManager.savePreferences()
+    }
+
+    // On dispose, mark leaving Zone
+    androidx.compose.runtime.DisposableEffect(Unit) {
+        onDispose {
+            preferenceManager.myPrefs.isInZoneScreen = false
+            preferenceManager.savePreferences()
+        }
+    }
+    
+    
     // Snackbar state
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
@@ -175,6 +203,68 @@ fun ZoneScreen(context: Context, onNavigate: (String) -> Unit) {
                     )
                 )
 
+                // Auto-play controls (interval + small toggle) only on TV tab
+                if (selectedTabIndex == 0) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            text = "Auto-play",
+                            style = MaterialTheme.typography.bodySmall,
+                            modifier = Modifier // Removed padding
+                        )
+
+                        // Small numeric interval (seconds)
+                        val initialInterval = preferenceManager.myPrefs.zoneAutoLoopIntervalSec
+                            .coerceIn(5, 600)
+                        var intervalText by remember { mutableStateOf(initialInterval.toString()) }
+
+                        androidx.compose.material3.OutlinedTextField(
+                            value = intervalText,
+                            onValueChange = { newVal ->
+                                val digits = newVal.filter { it.isDigit() }.take(3)
+                                intervalText = digits
+                                val parsed = digits.toIntOrNull()?.coerceIn(5, 600)
+                                if (parsed != null) {
+                                    preferenceManager.myPrefs.zoneAutoLoopIntervalSec = parsed
+                                    preferenceManager.savePreferences()
+                                }
+                            },
+                            singleLine = true,
+                            modifier = Modifier
+                                .size(55.dp, 60.dp) // Set both width and height
+                                .onFocusChanged { focusState ->
+                                    if (!focusState.isFocused) {
+                                        if (intervalText.isBlank()) {
+                                            intervalText = "20"
+                                            preferenceManager.myPrefs.zoneAutoLoopIntervalSec = 20
+                                            preferenceManager.savePreferences()
+                                        } else {
+                                            val parsed = intervalText.toIntOrNull()?.coerceIn(5, 600) ?: 20
+                                            intervalText = parsed.toString()
+                                            preferenceManager.myPrefs.zoneAutoLoopIntervalSec = parsed
+                                            preferenceManager.savePreferences()
+                                        }
+                                    }
+                                },
+                            textStyle = MaterialTheme.typography.bodySmall,
+                            placeholder = { Text("sec", style = MaterialTheme.typography.bodySmall) },
+                            label = { Text("sec", style = MaterialTheme.typography.bodySmall) },
+                            enabled = !zoneAutoLoopEnabled // Disable input if toggle is enabled
+                        )
+
+                        Spacer(modifier = Modifier.size(28.dp, 28.dp)) // Increased space between input and toggle
+
+                        androidx.compose.material3.Switch(
+                            checked = zoneAutoLoopEnabled,
+                            onCheckedChange = { enabled ->
+                                zoneAutoLoopEnabled = enabled
+                                preferenceManager.myPrefs.zoneAutoLoopEnabled = enabled
+                                preferenceManager.savePreferences()
+                            },
+                            modifier = Modifier.size(5.dp) // Changed size to make the toggle smaller
+                        )
+                    }
+                }
+
                 IconButton(onClick = { onNavigate("SettingsTV") }, modifier = Modifier.size(24.dp)) {
                     Icon(
                         imageVector = Icons.Default.Settings,
@@ -185,7 +275,7 @@ fun ZoneScreen(context: Context, onNavigate: (String) -> Unit) {
                 }
             }
 
-            // Tabs
+            // Tabs + Zone Auto-Loop Toggle
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -214,8 +304,10 @@ fun ZoneScreen(context: Context, onNavigate: (String) -> Unit) {
                         )
                     }
                 }
+            
+            Spacer(modifier = Modifier.weight(1f))
             }
-
+        
             // Tab Content
             when (selectedTabIndex) {
                 0 -> {
@@ -263,4 +355,127 @@ fun ZoneScreen(context: Context, onNavigate: (String) -> Unit) {
             selectedTabIndex = originalIndex
         }
     }
-}
+
+
+    // Scoped auto-play loop for Zone TV tab only
+    LaunchedEffect(selectedTabIndex, zoneAutoLoopEnabled, preferenceManager.myPrefs.zoneAutoLoopIntervalSec) {
+        if (selectedTabIndex != 0) return@LaunchedEffect
+        if (!zoneAutoLoopEnabled) return@LaunchedEffect
+
+        val port = preferenceManager.myPrefs.jtvGoServerPort
+        val baseUrl = "http://localhost:$port"
+
+        while (isActive && selectedTabIndex == 0 && zoneAutoLoopEnabled) {
+            try {
+                // respect user suppress window and current player state
+                val suppressUntil = preferenceManager.myPrefs.autoPlaySuppressUntil
+                val nowTs = System.currentTimeMillis()
+                if (suppressUntil > nowTs || preferenceManager.myPrefs.tvPlayerActive) {
+                    kotlinx.coroutines.delay(2000)
+                    continue
+                }
+
+                // If experimental custom playlist is enabled, prefer it for autoplay
+                val useCustom = preferenceManager.myPrefs.customPlaylistSupport && !preferenceManager.myPrefs.showPLAYLIST
+                if (useCustom) {
+                    val json = preferenceManager.myPrefs.channelListJson
+                    val channels: List<M3UChannelExp> = try {
+                        if (!json.isNullOrBlank()) {
+                            val type = object : TypeToken<List<M3UChannelExp>>() {}.type
+                            Gson().fromJson<List<M3UChannelExp>>(json, type)
+                        } else emptyList()
+                    } catch (_: Exception) { emptyList() }
+
+                    val allChannels = channels.distinctBy { it.url }
+                    if (allChannels.isNotEmpty()) {
+                        val selectedCategory = preferenceManager.myPrefs.lastSelectedCategoryExp ?: "All"
+                        val filtered = if (selectedCategory == "All") allChannels else allChannels.filter { it.category == selectedCategory }
+                        val effectiveList = if (filtered.isNotEmpty()) filtered else allChannels
+
+                        val prefCurrUrl = preferenceManager.myPrefs.currChannelUrl
+                        val selected = if (!prefCurrUrl.isNullOrEmpty()) {
+                            effectiveList.find { it.url == prefCurrUrl } ?: effectiveList.first()
+                        } else effectiveList.first()
+                        val selectedIndex = effectiveList.indexOf(selected).coerceAtLeast(0)
+
+                        try {
+                            val intent = Intent(context, com.skylake.skytv.jgorunner.services.player.ExoPlayJet::class.java).apply {
+                                putExtra("zone", "TV")
+                                putParcelableArrayListExtra(
+                                    "channel_list_data",
+                                    java.util.ArrayList(effectiveList.map { ch ->
+                                        com.skylake.skytv.jgorunner.activities.ChannelInfo(
+                                            ch.url,
+                                            ch.logo ?: "",
+                                            ch.name
+                                        )
+                                    })
+                                )
+                                putExtra("current_channel_index", selectedIndex)
+                                putExtra("video_url", selected.url)
+                                putExtra("logo_url", selected.logo ?: "")
+                                putExtra("ch_name", selected.name)
+                            }
+
+                            preferenceManager.myPrefs.tvPlayerActive = true
+                            preferenceManager.savePreferences()
+                            ContextCompat.startActivity(context, intent, null)
+                        } catch (_: Exception) { }
+                    }
+                } else {
+                    // Default zone UI: fetch channels from local server and autoplay
+                    val response = ChannelUtils.fetchChannels("$baseUrl/channels")
+                    val categoryIds = preferenceManager.myPrefs.filterCI
+                        ?.split(",")?.mapNotNull { it.trim().toIntOrNull() }?.filter { it != 0 }
+                        ?.takeIf { it.isNotEmpty() }
+                    val languageIds = preferenceManager.myPrefs.filterLI
+                        ?.split(",")?.mapNotNull { it.trim().toIntOrNull() }?.filter { it != 0 }
+                        ?.takeIf { it.isNotEmpty() }
+
+                    val list = ChannelUtils.filterChannels(
+                        response,
+                        languageIds = languageIds,
+                        categoryIds = categoryIds,
+                        isHD = null
+                    )
+                    if (list.isNotEmpty()) {
+                        val prefCurrUrl = preferenceManager.myPrefs.currChannelUrl
+                        val selected = if (!prefCurrUrl.isNullOrEmpty()) {
+                            list.find { it.channel_url == prefCurrUrl } ?: list.first()
+                        } else list.first()
+                        val selectedIndex = list.indexOf(selected).coerceAtLeast(0)
+
+                        try {
+                            val intent = Intent(context, com.skylake.skytv.jgorunner.services.player.ExoPlayJet::class.java).apply {
+                                putExtra("zone", "TV")
+                                putParcelableArrayListExtra(
+                                    "channel_list_data",
+                                    java.util.ArrayList(list.map { ch ->
+                                        com.skylake.skytv.jgorunner.activities.ChannelInfo(
+                                            ch.channel_url ?: "",
+                                            "http://localhost:$port/jtvimage/${ch.logoUrl ?: ""}",
+                                            ch.channel_name ?: ""
+                                        )
+                                    })
+                                )
+                                putExtra("current_channel_index", selectedIndex)
+                                putExtra("video_url", selected.channel_url ?: "")
+                                putExtra("logo_url", "http://localhost:$port/jtvimage/${selected.logoUrl ?: ""}")
+                                putExtra("ch_name", selected.channel_name ?: "")
+                            }
+
+                            preferenceManager.myPrefs.tvPlayerActive = true
+                            preferenceManager.savePreferences()
+                            ContextCompat.startActivity(context, intent, null)
+                        } catch (_: Exception) { }
+                    }
+                }
+            } catch (_: Exception) { }
+
+            // Wait user-defined interval (min 5s, max 600s)
+            val intervalMs = (preferenceManager.myPrefs.zoneAutoLoopIntervalSec
+                .coerceIn(5, 600)) * 1000L
+            kotlinx.coroutines.delay(intervalMs)
+        }
+    }}
+


### PR DESCRIPTION
Enable/Disable Autoplay: playback should start automatically within the Customizable delay(5s-600s).(By default it is 20s)
Work Side: The autoplay works only within the Zone ui .
If move to other page the autoplay will stop automatically .
If come back again to the Zone ui then the countdown of autoplay will start again.
Autoplay works fine for experimental Custom playlist Input.