### PR TITLE
Channel list add on zone player, remote direct channel change by number

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -126,6 +126,7 @@
 
         <activity
             android:name=".activities.InitModeSelectorActivity"
+            android:screenOrientation="sensor"
             android:theme="@style/Theme.JGO">
         </activity>
 
@@ -133,6 +134,7 @@
             android:name=".services.player.ExoPlayJet"
             android:theme="@style/Theme.JGO"
             android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation|keyboardHidden"
+            android:screenOrientation="sensor"
             android:resizeableActivity="true"
             android:supportsPictureInPicture="true"
             android:launchMode="singleTask" >


### PR DESCRIPTION
# Feature add :-- 
when playing any channel ne need to exit from the playing channel ,Now just press left arrow key (for tv) or the 3 dot icon on top to toggle the all channel list, and play the channel directly from the list .and on remote press the channel index number to play that channel, like playing 3rd channel now press 20 to play 20th channel.

# Demo video For that channel list

https://github.com/user-attachments/assets/ac695de0-0796-434a-a893-bca3275be13c

# Found a Bug
[Updated for your latest push (When custom playlist is disabled then language,category,show recent channel,quality not showing)This can be fixed like this,don't know your planning so i keep it as it is---- if (showPlaylist || !preferenceManager.myPrefs.customPlaylistSupport) { ---- ]

# Bug

https://github.com/user-attachments/assets/385d6ee0-df59-413b-a99e-a2499b4ad95a


