### PR TITLE
Working Widget

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-08-15T13:05:16.518273500Z">
+        <DropdownSelection timestamp="2025-10-14T13:05:09.063041300Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\SkyLake\.android\avd\Pixel_4_API_24.avd" />
+              <DeviceId pluginId="PhysicalDevice" identifier="serial=OZLZIRB6AUB6OBFQ" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -170,6 +170,24 @@
             </intent-filter>
         </receiver>
 
+        <!-- Server control App Widget -->
+        <receiver
+            android:name=".widgets.ServerWidgetProvider"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+                <action android:name="com.skylake.skytv.jgorunner.widgets.action.START_SERVER" />
+                <action android:name="com.skylake.skytv.jgorunner.widgets.action.STOP_SERVER" />
+                <action android:name="com.skylake.skytv.jgorunner.widgets.action.REFRESH" />
+                <action android:name="com.skylake.skytv.jgorunner.widgets.action.TOGGLE_LOGS" />
+                <action android:name="com.skylake.skytv.jgorunner.action.BINARY_STARTED" />
+                <action android:name="com.skylake.skytv.jgorunner.action.BINARY_STOPPED" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/widget_server_control_info" />
+        </receiver>
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.provider"

--- a/app/src/main/java/com/skylake/skytv/jgorunner/data/SkySharedPref.kt
+++ b/app/src/main/java/com/skylake/skytv/jgorunner/data/SkySharedPref.kt
@@ -159,6 +159,10 @@ class SkySharedPref(context: Context) {
         @SharedPrefKey("epgDebug") var epgDebug: Boolean = false,
         @SharedPrefKey("lastSelectedCategoriesExp") var lastSelectedCategoriesExp: String? = "",
 
+        // Widget-specific preferences
+        @SharedPrefKey("widget_show_logs") var widgetShowLogs: Boolean = false,
+        @SharedPrefKey("widget_logs") var widgetLogs: String? = ""
+
 
 
     )

--- a/app/src/main/java/com/skylake/skytv/jgorunner/widgets/ServerWidgetProvider.kt
+++ b/app/src/main/java/com/skylake/skytv/jgorunner/widgets/ServerWidgetProvider.kt
@@ -1,0 +1,171 @@
+package com.skylake.skytv.jgorunner.widgets
+
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.widget.RemoteViews
+import android.app.PendingIntent
+import com.skylake.skytv.jgorunner.R
+import com.skylake.skytv.jgorunner.data.SkySharedPref
+import com.skylake.skytv.jgorunner.services.BinaryService
+
+class ServerWidgetProvider : AppWidgetProvider() {
+
+    companion object {
+        const val ACTION_START_SERVER = "com.skylake.skytv.jgorunner.widgets.action.START_SERVER"
+        const val ACTION_STOP_SERVER = "com.skylake.skytv.jgorunner.widgets.action.STOP_SERVER"
+        const val ACTION_REFRESH = "com.skylake.skytv.jgorunner.widgets.action.REFRESH"
+        const val ACTION_TOGGLE_LOGS = "com.skylake.skytv.jgorunner.widgets.action.TOGGLE_LOGS"
+
+        private fun updateAllWidgets(context: Context) {
+            val appWidgetManager = AppWidgetManager.getInstance(context)
+            val componentName = ComponentName(context, ServerWidgetProvider::class.java)
+            val appWidgetIds = appWidgetManager.getAppWidgetIds(componentName)
+            for (id in appWidgetIds) {
+                updateAppWidget(context, appWidgetManager, id)
+            }
+        }
+
+        private fun getFullServerUrl(context: Context): String {
+            val prefs = SkySharedPref.getInstance(context).myPrefs
+            val port = prefs.jtvGoServerPort
+            val isPublic = !prefs.serveLocal
+
+            // Reuse logic similar to MainActivity.getPublicJTVServerURL()
+            if (!isPublic) return "http://localhost:$port/"
+
+            val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as android.net.ConnectivityManager
+            val activeNetwork = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+                connectivityManager.activeNetwork
+            } else {
+                @Suppress("deprecation")
+                val networks = connectivityManager.allNetworks
+                if (networks.isNotEmpty()) networks[0] else null
+            }
+
+            if (activeNetwork != null) {
+                val networkCapabilities = connectivityManager.getNetworkCapabilities(activeNetwork)
+                if (networkCapabilities != null &&
+                    (networkCapabilities.hasTransport(android.net.NetworkCapabilities.TRANSPORT_WIFI) ||
+                            networkCapabilities.hasTransport(android.net.NetworkCapabilities.TRANSPORT_ETHERNET))) {
+                    val linkProperties = connectivityManager.getLinkProperties(activeNetwork)
+                    val ipAddress = linkProperties?.linkAddresses
+                        ?.filter { it.address is java.net.Inet4Address }
+                        ?.map { it.address.hostAddress }
+                        ?.firstOrNull()
+                    if (ipAddress != null) return "http://$ipAddress:$port/"
+                }
+                // If cellular, fallback to localhost
+                if (networkCapabilities != null && networkCapabilities.hasTransport(android.net.NetworkCapabilities.TRANSPORT_CELLULAR)) {
+                    return "http://localhost:$port/"
+                }
+            }
+            return "http://localhost:$port/"
+        }
+
+        private fun updateAppWidget(context: Context, appWidgetManager: AppWidgetManager, appWidgetId: Int) {
+            val prefs = SkySharedPref.getInstance(context).myPrefs
+            val isRunning = BinaryService.isRunning
+            val port = prefs.jtvGoServerPort
+            val modeText = if (prefs.serveLocal) "Local" else "Public"
+            val statusText = if (isRunning) "Running" else "Stopped"
+            val fullUrl = getFullServerUrl(context)
+            val showLogs = prefs.widgetShowLogs
+            val logs = prefs.widgetLogs ?: ""
+
+            val views = RemoteViews(context.packageName, R.layout.widget_server_control)
+
+            views.setTextViewText(R.id.widget_status, "Status: $statusText")
+            views.setTextViewText(R.id.widget_port, "Port: $port")
+            views.setTextViewText(R.id.widget_mode, "Mode: $modeText")
+            views.setTextViewText(R.id.widget_url, "URL: $fullUrl")
+            views.setTextViewText(R.id.widget_logs, if (showLogs) logs else "")
+            views.setViewVisibility(R.id.widget_logs, if (showLogs) android.view.View.VISIBLE else android.view.View.GONE)
+            views.setTextViewText(R.id.widget_toggle_logs_button, if (showLogs) "Hide Logs" else "Show Logs")
+
+            // Start server pending intent
+            val startIntent = Intent(context, ServerWidgetProvider::class.java).apply { action = ACTION_START_SERVER }
+            val startPending = PendingIntent.getBroadcast(
+                context,
+                0,
+                startIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) PendingIntent.FLAG_IMMUTABLE else 0
+            )
+            views.setOnClickPendingIntent(R.id.widget_start_button, startPending)
+
+            // Stop server pending intent
+            val stopIntent = Intent(context, ServerWidgetProvider::class.java).apply { action = ACTION_STOP_SERVER }
+            val stopPending = PendingIntent.getBroadcast(
+                context,
+                1,
+                stopIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) PendingIntent.FLAG_IMMUTABLE else 0
+            )
+            views.setOnClickPendingIntent(R.id.widget_stop_button, stopPending)
+
+            // Refresh pending intent
+            val refreshIntent = Intent(context, ServerWidgetProvider::class.java).apply { action = ACTION_REFRESH }
+            val refreshPending = PendingIntent.getBroadcast(
+                context,
+                2,
+                refreshIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) PendingIntent.FLAG_IMMUTABLE else 0
+            )
+            views.setOnClickPendingIntent(R.id.widget_refresh_button, refreshPending)
+
+            // Toggle logs pending intent
+            val toggleIntent = Intent(context, ServerWidgetProvider::class.java).apply { action = ACTION_TOGGLE_LOGS }
+            val togglePending = PendingIntent.getBroadcast(
+                context,
+                3,
+                toggleIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) PendingIntent.FLAG_IMMUTABLE else 0
+            )
+            views.setOnClickPendingIntent(R.id.widget_toggle_logs_button, togglePending)
+
+            appWidgetManager.updateAppWidget(appWidgetId, views)
+        }
+    }
+
+    override fun onUpdate(context: Context, appWidgetManager: AppWidgetManager, appWidgetIds: IntArray) {
+        for (appWidgetId in appWidgetIds) {
+            updateAppWidget(context, appWidgetManager, appWidgetId)
+        }
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        super.onReceive(context, intent)
+        when (intent.action) {
+            ACTION_START_SERVER -> {
+                val serviceIntent = Intent(context, BinaryService::class.java)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    context.startForegroundService(serviceIntent)
+                } else {
+                    context.startService(serviceIntent)
+                }
+                updateAllWidgets(context)
+            }
+            ACTION_STOP_SERVER -> {
+                val stopIntent = Intent(context, BinaryService::class.java).apply {
+                    action = BinaryService.ACTION_STOP_BINARY
+                }
+                context.startService(stopIntent)
+                updateAllWidgets(context)
+            }
+            ACTION_TOGGLE_LOGS -> {
+                val pref = SkySharedPref.getInstance(context)
+                pref.myPrefs.widgetShowLogs = !pref.myPrefs.widgetShowLogs
+                pref.savePreferences()
+                updateAllWidgets(context)
+            }
+            ACTION_REFRESH, AppWidgetManager.ACTION_APPWIDGET_UPDATE,
+            BinaryService.ACTION_BINARY_STOPPED,
+            BinaryService.ACTION_BINARY_STARTED -> {
+                updateAllWidgets(context)
+            }
+        }
+    }
+}

--- a/app/src/main/res/drawable/widget_bg.xml
+++ b/app/src/main/res/drawable/widget_bg.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <corners android:radius="12dp" />
+    <gradient
+        android:startColor="#303F9F"
+        android:endColor="#1A237E"
+        android:angle="45" />
+    <padding
+        android:left="8dp"
+        android:top="8dp"
+        android:right="8dp"
+        android:bottom="8dp" />
+</shape>

--- a/app/src/main/res/layout/widget_server_control.xml
+++ b/app/src/main/res/layout/widget_server_control.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="12dp"
+    android:background="@drawable/widget_bg">
+
+    <TextView
+        android:id="@+id/widget_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="JTV-Go Server"
+        android:textStyle="bold"
+        android:textSize="16sp"
+        android:textColor="#FFFFFF"
+        android:ellipsize="end"
+        android:maxLines="1" />
+
+    <TextView
+        android:id="@+id/widget_status"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Status: -"
+        android:textSize="14sp"
+        android:textColor="#FFFFFF"
+        android:ellipsize="end"
+        android:maxLines="1" />
+
+    <TextView
+        android:id="@+id/widget_port"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Port: -"
+        android:textSize="14sp"
+        android:textColor="#FFFFFF"
+        android:ellipsize="end"
+        android:maxLines="1" />
+
+    <TextView
+        android:id="@+id/widget_mode"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Mode: -"
+        android:textSize="14sp"
+        android:textColor="#FFFFFF"
+        android:ellipsize="end"
+        android:maxLines="1" />
+
+    <TextView
+        android:id="@+id/widget_url"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="URL: -"
+        android:textSize="14sp"
+        android:textColor="#BBDEFB"
+        android:autoLink="web"
+        android:ellipsize="end"
+        android:maxLines="1" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center"
+        android:layout_marginTop="8dp">
+
+        <Button
+            android:id="@+id/widget_start_button"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="Start" />
+
+        <Button
+            android:id="@+id/widget_stop_button"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="Stop" />
+
+        <ImageButton
+            android:id="@+id/widget_refresh_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@android:drawable/ic_popup_sync"
+            android:tint="#FFFFFF"
+            android:background="@android:color/transparent"
+            android:contentDescription="Refresh" />
+    </LinearLayout>
+
+    <Button
+        android:id="@+id/widget_toggle_logs_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Show Logs"
+        android:layout_marginTop="6dp"
+        android:textColor="#FFFFFF" />
+
+    <TextView
+        android:id="@+id/widget_logs"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text=""
+        android:textColor="#E0E0E0"
+        android:layout_marginTop="6dp"
+        android:maxLines="8"
+        android:ellipsize="end" />
+
+</LinearLayout>

--- a/app/src/main/res/xml/widget_server_control_info.xml
+++ b/app/src/main/res/xml/widget_server_control_info.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="200dp"
+    android:minHeight="100dp"
+    android:updatePeriodMillis="0"
+    android:initialLayout="@layout/widget_server_control"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen" />


### PR DESCRIPTION
- Added a “Server Control” home-screen widget that shows server status, port, mode, and the complete URL.
- Supports "start"/"stop"/"refresh" actions directly from the widget.
- Provides a “Show/Hide Logs” toggle to display recent binary output for quick diagnostics.
- Improves visual design with a rounded, gradient background, clear text hierarchy, and button/icon styling.
- Auto-links the displayed URL so users can tap to open it in the browser.

Complete details at https://github.com/JioTV-Go/jiotv_go_app/issues/84

# Screenshots
![Screenshot_2025-10-14-19-16-31-65_b783bf344239542886fee7b48fa4b892](https://github.com/user-attachments/assets/dace25ff-4af8-4704-b6ef-6a37ba0f6d27)
![Screenshot_2025-10-14-19-16-46-66_b783bf344239542886fee7b48fa4b892](https://github.com/user-attachments/assets/a410ce8a-82d2-43ba-9840-363adb044221)

